### PR TITLE
feat: upgrade GLM to v4.7 and refactor model constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A command-line interface for launching Claude Code with GLM (ChatGLM) settings v
 ## Features
 
 - 🚀 **Session-Based Launch**: Launch Claude with GLM settings temporarily (no persistent config changes)
-- 🎯 **Model Selection**: Choose different GLM models at launch time (glm-4.6, glm-4.5, glm-4.5-air, etc.)
+- 🎯 **Model Selection**: Choose different GLM models at launch time (glm-4.7, glm-4.6, glm-4.5, glm-4.5-air, etc.)
 - 📦 **Auto-Install**: Install Claude Code with built-in npm dependency checking
 - 🔄 **Auto-Update**: Check for and install updates with interactive update command
 - ⚙️ **Token Management**: Securely manage your authentication token
@@ -97,7 +97,7 @@ glm
 
 ### Launch Claude with GLM (Primary Usage)
 
-Launch Claude with the default model (glm-4.6):
+Launch Claude with the default model (glm-4.7):
 ```bash
 glm
 ```
@@ -169,7 +169,7 @@ glm update --help
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| `glm` | Launch Claude with GLM (temporary config) | `glm --model glm-4.6` |
+| `glm` | Launch Claude with GLM (temporary config) | `glm --model glm-4.7` |
 | `glm install claude` | Install Claude Code | `glm install claude` |
 | `glm token set` | Set authentication token | `glm token set` |
 | `glm token show` | Show current token (masked) | `glm token show` |
@@ -189,7 +189,8 @@ These commands still work but are deprecated. Use `glm` with `--model` flag inst
 
 ## Available Models
 
-- `glm-4.6` (default)
+- `glm-4.7` (default)
+- `glm-4.6`
 - `glm-4.5`
 - `glm-4.5-air`
 - Any other GLM model supported by BigModel API
@@ -226,7 +227,7 @@ curl -fsSL https://raw.githubusercontent.com/xqsit94/glm/main/install.sh | bash
 glm install claude        # Install Claude Code
 glm token set            # Enter your token securely
 
-# Launch Claude with GLM (default model: glm-4.6)
+# Launch Claude with GLM (default model: glm-4.7)
 glm
 
 # Launch with specific model

--- a/cmd/enable.go
+++ b/cmd/enable.go
@@ -31,7 +31,7 @@ func EnableCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("model", "m", defaultModel, fmt.Sprintf("GLM model to use (default: %s)", defaultModel))
+	cmd.Flags().StringP("model", "m", token.DefaultModel, fmt.Sprintf("GLM model to use (default: %s)", token.DefaultModel))
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,8 +11,7 @@ import (
 )
 
 const (
-	version      = "1.1.0"
-	defaultModel = "glm-4.6"
+	version = "1.1.1"
 )
 
 func RootCmd() *cobra.Command {
@@ -28,7 +27,7 @@ func RootCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&model, "model", "m", defaultModel, "GLM model to use for this session")
+	cmd.Flags().StringVarP(&model, "model", "m", token.DefaultModel, "GLM model to use for this session")
 
 	return cmd
 }

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/term"
 )
 
-const defaultModel = "glm-4.6"
+const DefaultModel = "glm-4.7"
 
 func Get() (string, error) {
 	if token := os.Getenv("ANTHROPIC_AUTH_TOKEN"); token != "" {
@@ -64,7 +64,7 @@ func Set() error {
 
 	cfg.AnthropicAuthToken = tokenStr
 	if cfg.DefaultModel == "" {
-		cfg.DefaultModel = defaultModel
+		cfg.DefaultModel = DefaultModel
 	}
 
 	if err := config.Save(cfg); err != nil {


### PR DESCRIPTION
## Summary

- Upgraded CLI version from 1.1.0 to 1.1.1
- Updated default model from glm-4.6 to glm-4.7
- Refactored duplicate model constants into a single source of truth

## Changes

**Version & Model Update:**
- Updated version constant in cmd/root.go to 1.1.1
- Changed default model from glm-4.6 to glm-4.7
- Updated README.md to reflect glm-4.7 as the new default while keeping glm-4.6 as an available option

**Code Refactoring:**
- Exported `DefaultModel` constant from `internal/token/token.go` as the single source of truth
- Updated `cmd/root.go` to remove duplicate constant and use `token.DefaultModel`
- Updated `cmd/enable.go` to use `token.DefaultModel`
- Eliminated code duplication across command implementations

## Files Changed

- `cmd/root.go` - Version bump and constant refactoring
- `cmd/enable.go` - Use centralized model constant
- `internal/token/token.go` - Export DefaultModel constant
- `README.md` - Documentation updates for glm-4.7

## Benefits

- Single source of truth for default model configuration
- Improved maintainability with no duplicate constants
- Easier future model updates (only need to change one location)
- Cleaner codebase following DRY principle