### PR TITLE
feat: add flag passthrough to claude command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,8 +108,10 @@ func runDefaultAction(cmd *cobra.Command, model string) error {
 	fmt.Printf("📝 Using model: %s\n", model)
 	fmt.Println("🎯 Starting Claude Code with temporary GLM configuration...")
 
-	// Build claude command with passthrough flags
-	cmdArgs := []string{"claude"}
+	// Build claude command with explicit model to override settings.json
+	// This prevents extended thinking modes (like opusplan) from being used
+	// with GLM API which doesn't support thinking blocks
+	cmdArgs := []string{"claude", "--model", model}
 	unknownFlags := extractUnknownFlags(cmd)
 	cmdArgs = append(cmdArgs, unknownFlags...)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,7 @@ func extractUnknownFlags(cmd *cobra.Command) []string {
 			unknown = append(unknown, arg)
 			// Also skip the next arg if it's a flag value (not starting with -)
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				unknown = append(unknown, args[i+1]) // Add the value too
 				skipNext = true
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
+	"github.com/spf13/pflag"
 	"github.com/xqsit94/glm/internal/token"
 
 	"github.com/spf13/cobra"
@@ -23,16 +25,73 @@ func RootCmd() *cobra.Command {
 		Long:    "A CLI tool to launch Claude with GLM settings using temporary session-based configuration",
 		Version: version,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDefaultAction(model)
+			return runDefaultAction(cmd, model)
 		},
 	}
 
 	cmd.Flags().StringVarP(&model, "model", "m", token.DefaultModel, "GLM model to use for this session")
 
+	// Allow unknown flags to be passed through to claude
+	cmd.FParseErrWhitelist.UnknownFlags = true
+
 	return cmd
 }
 
-func runDefaultAction(model string) error {
+// extractUnknownFlags extracts flags from os.Args that are not known to glm
+// This allows passthrough of arbitrary flags to the claude command
+func extractUnknownFlags(cmd *cobra.Command) []string {
+	knownFlags := make(map[string]bool)
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		knownFlags["--"+f.Name] = true
+		if f.Shorthand != "" {
+			knownFlags["-"+f.Shorthand] = true
+		}
+	})
+
+	var unknown []string
+	args := os.Args[1:] // Skip program name
+
+	skipNext := false
+	for i, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+
+		// Skip if it's a known flag
+		if knownFlags[arg] {
+			// Also skip the next arg if it's a flag value (not starting with -)
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				skipNext = true
+			}
+			continue
+		}
+
+		// Handle --flag=value format
+		if strings.HasPrefix(arg, "--") {
+			if idx := strings.Index(arg, "="); idx != -1 {
+				flagName := arg[:idx]
+				if !knownFlags[flagName] {
+					unknown = append(unknown, arg)
+				}
+				continue
+			}
+		}
+
+		// If it starts with -, it's a flag (and we don't know it)
+		if strings.HasPrefix(arg, "-") {
+			unknown = append(unknown, arg)
+			// Also skip the next arg if it's a flag value (not starting with -)
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				skipNext = true
+			}
+		}
+	}
+
+	return unknown
+}
+
+func runDefaultAction(cmd *cobra.Command, model string) error {
 	fmt.Println("🚀 Launching Claude with GLM...")
 
 	authToken, err := token.Get()
@@ -49,17 +108,22 @@ func runDefaultAction(model string) error {
 	fmt.Printf("📝 Using model: %s\n", model)
 	fmt.Println("🎯 Starting Claude Code with temporary GLM configuration...")
 
-	cmd := exec.Command("claude")
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(),
+	// Build claude command with passthrough flags
+	cmdArgs := []string{"claude"}
+	unknownFlags := extractUnknownFlags(cmd)
+	cmdArgs = append(cmdArgs, unknownFlags...)
+
+	claudeCmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	claudeCmd.Stdin = os.Stdin
+	claudeCmd.Stdout = os.Stdout
+	claudeCmd.Stderr = os.Stderr
+	claudeCmd.Env = append(os.Environ(),
 		"ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic",
 		"ANTHROPIC_AUTH_TOKEN="+authToken,
 		"ANTHROPIC_MODEL="+model,
 	)
 
-	if err := cmd.Run(); err != nil {
+	if err := claudeCmd.Run(); err != nil {
 		return fmt.Errorf("failed to run claude: %v", err)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ const (
 
 func RootCmd() *cobra.Command {
 	var model string
+	var yolo bool
 
 	cmd := &cobra.Command{
 		Use:     "glm",
@@ -25,11 +26,12 @@ func RootCmd() *cobra.Command {
 		Long:    "A CLI tool to launch Claude with GLM settings using temporary session-based configuration",
 		Version: version,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDefaultAction(cmd, model)
+			return runDefaultAction(cmd, model, yolo)
 		},
 	}
 
 	cmd.Flags().StringVarP(&model, "model", "m", token.DefaultModel, "GLM model to use for this session")
+	cmd.Flags().BoolVar(&yolo, "yolo", false, "Skip permission prompts (--dangerously-skip-permissions)")
 
 	// Allow unknown flags to be passed through to claude
 	cmd.FParseErrWhitelist.UnknownFlags = true
@@ -91,7 +93,7 @@ func extractUnknownFlags(cmd *cobra.Command) []string {
 	return unknown
 }
 
-func runDefaultAction(cmd *cobra.Command, model string) error {
+func runDefaultAction(cmd *cobra.Command, model string, yolo bool) error {
 	fmt.Println("🚀 Launching Claude with GLM...")
 
 	authToken, err := token.Get()
@@ -112,6 +114,9 @@ func runDefaultAction(cmd *cobra.Command, model string) error {
 	// This prevents extended thinking modes (like opusplan) from being used
 	// with GLM API which doesn't support thinking blocks
 	cmdArgs := []string{"claude", "--model", model}
+	if yolo {
+		cmdArgs = append(cmdArgs, "--dangerously-skip-permissions")
+	}
 	unknownFlags := extractUnknownFlags(cmd)
 	cmdArgs = append(cmdArgs, unknownFlags...)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	version = "1.1.1"
+	version = "1.2.0"
 )
 
 func RootCmd() *cobra.Command {
@@ -32,8 +32,6 @@ func RootCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&model, "model", "m", token.DefaultModel, "GLM model to use for this session")
 	cmd.Flags().BoolVar(&yolo, "yolo", false, "Skip permission prompts (--dangerously-skip-permissions)")
-
-	// Allow unknown flags to be passed through to claude
 	cmd.FParseErrWhitelist.UnknownFlags = true
 
 	return cmd
@@ -51,7 +49,7 @@ func extractUnknownFlags(cmd *cobra.Command) []string {
 	})
 
 	var unknown []string
-	args := os.Args[1:] // Skip program name
+	args := os.Args[1:]
 
 	skipNext := false
 	for i, arg := range args {
@@ -60,16 +58,13 @@ func extractUnknownFlags(cmd *cobra.Command) []string {
 			continue
 		}
 
-		// Skip if it's a known flag
 		if knownFlags[arg] {
-			// Also skip the next arg if it's a flag value (not starting with -)
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 				skipNext = true
 			}
 			continue
 		}
 
-		// Handle --flag=value format
 		if strings.HasPrefix(arg, "--") {
 			if idx := strings.Index(arg, "="); idx != -1 {
 				flagName := arg[:idx]
@@ -80,12 +75,10 @@ func extractUnknownFlags(cmd *cobra.Command) []string {
 			}
 		}
 
-		// If it starts with -, it's a flag (and we don't know it)
 		if strings.HasPrefix(arg, "-") {
 			unknown = append(unknown, arg)
-			// Also skip the next arg if it's a flag value (not starting with -)
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				unknown = append(unknown, args[i+1]) // Add the value too
+				unknown = append(unknown, args[i+1])
 				skipNext = true
 			}
 		}
@@ -111,9 +104,6 @@ func runDefaultAction(cmd *cobra.Command, model string, yolo bool) error {
 	fmt.Printf("📝 Using model: %s\n", model)
 	fmt.Println("🎯 Starting Claude Code with temporary GLM configuration...")
 
-	// Build claude command with explicit model to override settings.json
-	// This prevents extended thinking modes (like opusplan) from being used
-	// with GLM API which doesn't support thinking blocks
 	cmdArgs := []string{"claude", "--model", model}
 	if yolo {
 		cmdArgs = append(cmdArgs, "--dangerously-skip-permissions")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestExtractUnknownFlags(t *testing.T) {
+	// Create a test command with some known flags
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("model", "m", "", "Model to use")
+	cmd.Flags().BoolP("yolo", "y", false, "Skip permissions")
+
+	tests := []struct {
+		name           string
+		args           []string
+		expectedUnknown []string
+	}{
+		{
+			name:           "no args",
+			args:           []string{},
+			expectedUnknown: []string{},
+		},
+		{
+			name:           "only known flags",
+			args:           []string{"--model", "gpt-4"},
+			expectedUnknown: []string{},
+		},
+		{
+			name:           "unknown flag with value",
+			args:           []string{"--allowedTools", "Bash,Read"},
+			expectedUnknown: []string{"--allowedTools", "Bash,Read"},
+		},
+		{
+			name:           "unknown flag with value and known flag",
+			args:           []string{"--model", "gpt-4", "--allowedTools", "Bash,Read"},
+			expectedUnknown: []string{"--allowedTools", "Bash,Read"},
+		},
+		{
+			name:           "unknown flag with equals value",
+			args:           []string{"--allowedTools=Bash,Read"},
+			expectedUnknown: []string{"--allowedTools=Bash,Read"},
+		},
+		{
+			name:           "unknown shorthand flag with value",
+			args:           []string{"-x", "value"},
+			expectedUnknown: []string{"-x", "value"},
+		},
+		{
+			name:           "multiple unknown flags with values",
+			args:           []string{"--foo", "bar", "--baz", "qux"},
+			expectedUnknown: []string{"--foo", "bar", "--baz", "qux"},
+		},
+		{
+			name:           "mix of known and unknown flags",
+			args:           []string{"--model", "gpt-4", "--foo", "bar", "-y", "--baz", "qux"},
+			expectedUnknown: []string{"--foo", "bar", "--baz", "qux"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original args and restore after test
+			originalArgs := os.Args
+			defer func() { os.Args = originalArgs }()
+
+			// Set up os.Args for this test
+			os.Args = append([]string{"glm"}, tt.args...)
+
+			result := extractUnknownFlags(cmd)
+
+			if !equalSlices(result, tt.expectedUnknown) {
+				t.Errorf("extractUnknownFlags() = %v, want %v", result, tt.expectedUnknown)
+			}
+		})
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- Allow unknown flags to be passed through directly to the claude CLI
- Users can now use claude-specific flags like `--dangerously-skip-permissions` without glm needing to explicitly define each one

## Test plan
- [x] Tested with `./glm --dangerously-skip-permissions`
- [x] Existing `--model` flag still works correctly
- [x] Multiple unknown flags can be passed simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)