### PR TITLE
fix: pass model to Claude via --model flag instead of env var

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ const (
 
 func RootCmd() *cobra.Command {
 	var model string
+	var yolo bool
 
 	cmd := &cobra.Command{
 		Use:     "glm",
@@ -23,16 +24,17 @@ func RootCmd() *cobra.Command {
 		Long:    "A CLI tool to launch Claude with GLM settings using temporary session-based configuration",
 		Version: version,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDefaultAction(model)
+			return runDefaultAction(model, yolo)
 		},
 	}
 
 	cmd.Flags().StringVarP(&model, "model", "m", token.DefaultModel, "GLM model to use for this session")
+	cmd.Flags().BoolVar(&yolo, "yolo", false, "Skip permission prompts (--dangerously-skip-permissions)")
 
 	return cmd
 }
 
-func runDefaultAction(model string) error {
+func runDefaultAction(model string, yolo bool) error {
 	fmt.Println("🚀 Launching Claude with GLM...")
 
 	authToken, err := token.Get()
@@ -49,7 +51,14 @@ func runDefaultAction(model string) error {
 	fmt.Printf("📝 Using model: %s\n", model)
 	fmt.Println("🎯 Starting Claude Code with temporary GLM configuration...")
 
-	cmd := exec.Command("claude")
+	args := []string{"--model", model}
+
+	// Append passthrough flags
+	if yolo {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+
+	cmd := exec.Command("claude", args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Problem
Previously, `glm` set `ANTHROPIC_MODEL` as an environment variable, but Claude CLI ignores this and only respects the `--model` command-line flag. This caused `--model` flag values to be ignored, defaulting to opus.

```bash
# Before this fix - this didn't work as expected:
glm --model glm-5   # Claude would still use opus/GLM-4.7
```

## Solution
Pass the model directly to Claude CLI via the `--model` flag.

## Changes
- Pass `--model` flag directly to Claude CLI (e.g., `claude --model glm-5`)
- Keep `ANTHROPIC_MODEL` env var for tools/agents that may read it
- Properly implement `--yolo` flag passthrough as `--dangerously-skip-permissions`

## Testing
After this fix:
```bash
glm --model glm-5        # Uses glm-5
glm --model glm-6        # Will work when glm-6 is released (no code change needed)
glm -m glm-4.5         # Short flag also works
glm --yolo              # Both flags can combine
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)